### PR TITLE
코스피 수익률 컴포넌트 구현 및 ETF UI 수정

### DIFF
--- a/src/components/ETF/Detail/Chart/Chart.jsx
+++ b/src/components/ETF/Detail/Chart/Chart.jsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Graph from "./Graph";
 import PeriodTabBar from "../PeriodTabBar";
 import Tip from "~/components/Tip/Tip";
+import Kospi from "~/components/Kospi/Kospi";
 
 export default function Chart(props) {
   const code = props.code;
@@ -24,6 +25,10 @@ export default function Chart(props) {
         currentPeriod={currentPeriod}
         setCurrentPeriod={setCurrentPeriod}
       />
+
+      <div>
+        <Kospi currentPeriod={currentPeriod} />
+      </div>
 
       <div className="mt-12 mb-20">
         <Tip />

--- a/src/components/ETF/Detail/Chart/Graph.jsx
+++ b/src/components/ETF/Detail/Chart/Graph.jsx
@@ -14,28 +14,26 @@ export default function Graph(props) {
 
   let formattedData = [];
 
-  for (
-    let i = Math.max(chartData.length - size, 0);
-    i < chartData.length;
-    i++
-  ) {
-    const ele = chartData[i];
+  if (chartData.length > 0) {
+    for (let i = Math.min(chartData.length - 1, size - 1); i >= 0; i--) {
+      const ele = chartData[i];
 
-    if (isFund) {
-      const parsedY = parseFloat(ele.기준가.replace(",", ""));
+      if (isFund) {
+        const parsedY = parseFloat(ele.기준가.replace(",", ""));
+
+        formattedData.push({
+          x: ele.기준일,
+          y: parsedY,
+        });
+
+        continue;
+      }
 
       formattedData.push({
-        x: ele.기준일,
-        y: parsedY,
+        x: ele.stck_bsop_date,
+        y: ele.stck_clpr,
       });
-
-      continue;
     }
-
-    formattedData.push({
-      x: ele.stck_bsop_date,
-      y: ele.stck_clpr,
-    });
   }
 
   const data = [

--- a/src/components/Kospi/Kospi.jsx
+++ b/src/components/Kospi/Kospi.jsx
@@ -6,6 +6,8 @@ export default function Kospi(props) {
   const currentPeriod = props.currentPeriod;
 
   const [kospi, setKospi] = useState();
+  const [message, setMessage] = useState();
+  const [style, setStyle] = useState("");
 
   useEffect(() => {
     const resp = getKospiPrices().then((resp) => {
@@ -13,17 +15,39 @@ export default function Kospi(props) {
     });
   }, []);
 
-  if (kospi) {
-    const kospiChange =
-      (kospi[0].closePrice - kospi[currentPeriod + 1].closePrice) /
-      kospi[currentPeriod + 1].closePrice;
-    console.log(
-      "kos: ",
-      kospi[0].closePrice,
-      kospi[currentPeriod + 1].closePrice,
-      kospiChange
-    );
-  }
+  useEffect(() => {
+    if (kospi) {
+      const currentPrice = kospi[0].closePrice;
+      const pastPrice = kospi[currentPeriod + 1].closePrice;
+      const kospiChange = (
+        ((currentPrice - pastPrice) / pastPrice) *
+        100
+      ).toFixed(2);
 
-  return <div>Kospi</div>;
+      console.log(
+        "kos: ",
+        kospi[0].closePrice,
+        kospi[currentPeriod + 1].closePrice,
+        kospiChange
+      );
+
+      console.log("kospi[0]: ", kospiChange[0]);
+      if (kospiChange[0] === "-") {
+        console.log("minus : ", kospiChange.substring(1));
+        setMessage(kospiChange.substring(1) + "% 하락");
+        setStyle("text-blue-500");
+      } else {
+        setMessage(kospiChange + "% 상승");
+        setStyle("text-red-500");
+      }
+    }
+  }, [kospi, currentPeriod]);
+
+  return (
+    <div className="text-center m-4 text-md font-semibold">
+      <p>
+        같은기간, 코스피는 <span className={style}>{message}</span>했어요
+      </p>
+    </div>
+  );
 }

--- a/src/components/Kospi/Kospi.jsx
+++ b/src/components/Kospi/Kospi.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from "react";
+
+import { getKospiPrices } from "~/lib/apis/kospi";
+
+export default function Kospi(props) {
+  const currentPeriod = props.currentPeriod;
+
+  const [kospi, setKospi] = useState();
+
+  useEffect(() => {
+    const resp = getKospiPrices().then((resp) => {
+      setKospi(resp[0].data);
+    });
+  }, []);
+
+  if (kospi) {
+    const kospiChange =
+      (kospi[0].closePrice - kospi[currentPeriod + 1].closePrice) /
+      kospi[currentPeriod + 1].closePrice;
+    console.log(
+      "kos: ",
+      kospi[0].closePrice,
+      kospi[currentPeriod + 1].closePrice,
+      kospiChange
+    );
+  }
+
+  return <div>Kospi</div>;
+}

--- a/src/lib/apis/kospi.js
+++ b/src/lib/apis/kospi.js
@@ -1,0 +1,12 @@
+import axios from "axios";
+
+export const getKospiPrices = async () => {
+  try {
+    const url = "/api/kospi";
+    const resp = await axios.get(url);
+
+    return resp.data;
+  } catch (err) {
+    console.log(err);
+  }
+};


### PR DESCRIPTION
## 📌 작업 내용
- 코스피 수익률 컴포넌트 구현
- etf 메인페이지, 연말정산 첫 페이지에 뒤로가기 버튼
- etf 메인페이지의 카드 온클릭 수정 (좋아요 눌러도 상세페이지로 넘어가던 거 수정)

## 🌱 관련 이슈
- close #

## 📚 기타
